### PR TITLE
[Feat/#9] 버튼 컴포넌트 제작

### DIFF
--- a/.storybook/preview.module.scss
+++ b/.storybook/preview.module.scss
@@ -1,3 +1,7 @@
+body {
+  max-width: initial;
+}
+
 .Wrapper {
   display: flex;
   flex-flow: row wrap;

--- a/.storybook/preview.module.scss
+++ b/.storybook/preview.module.scss
@@ -10,5 +10,13 @@
 .Story {
   height: 100%;
   padding: 2.5rem;
-  background-color: gray;
+  background-color: white;
+  color: black;
+}
+
+.InverseStory {
+  height: 100%;
+  padding: 2.5rem;
+  background-color: black;
+  color: white;
 }

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,6 +18,10 @@ const preview: Preview = {
         <div className={styles.Story}>
           <Story />
         </div>
+
+        <div className={styles.InverseStory}>
+          <Story />
+        </div>
       </div>
     ),
   ],

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,7 @@
 import type { Preview } from "@storybook/react";
 
+import "@/styles/reset.scss";
+import "@/styles/global.scss";
 import styles from "./preview.module.scss";
 
 const preview: Preview = {

--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -1,0 +1,9 @@
+.Test {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 300px;
+  align-items: center;
+  margin: 0 auto;
+  margin-top: 40px;
+}

--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -7,3 +7,17 @@
   margin: 0 auto;
   margin-top: 40px;
 }
+
+.Test2 {
+  width: 161px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.Test3 {
+  width: 99px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,12 @@
+import Button from "@/components/ui/Button/Button";
+
 const App = () => {
-  return <div>App</div>;
+  return (
+    <div>
+      <Button variant="primary" />
+      <Button variant="secondary" />
+    </div>
+  );
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ const App = () => {
     <div className={styles.Test}>
       <Button variant="primary" text="정보가 맞아요" />
       <Button variant="secondary" text="정보가 맞아요" />
-      <Button variant="disabled" text="다시 스캔하기" />
+      <Button variant="tertiary" text="다시 스캔하기" />
       <div className={styles.Test2}>
         <IconButton text="갤러리" iconName="gallery" />
         <IconButton text="카메라" iconName="camera" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
+import styles from "./App.module.scss";
+
 import Button from "@/components/ui/Button/Button";
 
 const App = () => {
   return (
-    <div>
-      <Button variant="primary" />
-      <Button variant="secondary" />
+    <div className={styles.Test}>
+      <Button variant="primary" text="정보가 맞아요" />
+      <Button variant="secondary" text="정보가 맞아요" />
+      <Button variant="disabled" text="다시 스캔하기" />
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import styles from "./App.module.scss";
 
 import Button from "@/components/ui/Button/Button";
+import IconButton from "@/components/ui/IconButton/IconButton";
 
 const App = () => {
   return (
@@ -8,6 +9,13 @@ const App = () => {
       <Button variant="primary" text="정보가 맞아요" />
       <Button variant="secondary" text="정보가 맞아요" />
       <Button variant="disabled" text="다시 스캔하기" />
+      <div className={styles.Test2}>
+        <IconButton text="갤러리" iconName="gallery" />
+        <IconButton text="카메라" iconName="camera" />
+      </div>
+      <div className={styles.Test3}>
+        <IconButton size="sm" text="복사하기" iconName="paste" />
+      </div>
     </div>
   );
 };

--- a/src/components/ui/BaseButton/BaseButton.module.scss
+++ b/src/components/ui/BaseButton/BaseButton.module.scss
@@ -1,0 +1,10 @@
+@use "@/styles/mixins" as *;
+
+.BaseButton {
+  cursor: pointer;
+  margin: 0;
+  border: none;
+  border-radius: 0.875rem;
+  width: 100%;
+  height: 3.25rem;
+}

--- a/src/components/ui/BaseButton/BaseButton.module.scss
+++ b/src/components/ui/BaseButton/BaseButton.module.scss
@@ -5,4 +5,5 @@
   border-radius: 0.875rem;
   width: 100%;
   height: 3.25rem;
+  padding: 0.875rem;
 }

--- a/src/components/ui/BaseButton/BaseButton.module.scss
+++ b/src/components/ui/BaseButton/BaseButton.module.scss
@@ -2,8 +2,6 @@
 
 .BaseButton {
   cursor: pointer;
-  margin: 0;
-  border: none;
   border-radius: 0.875rem;
   width: 100%;
   height: 3.25rem;

--- a/src/components/ui/BaseButton/BaseButton.tsx
+++ b/src/components/ui/BaseButton/BaseButton.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import classNames from "classnames";
+
+import styles from "@/components/ui/BaseButton/BaseButton.module.scss";
+import type { BaseButtonProps } from "@/components/ui/BaseButton/BaseButton.types";
+
+const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(
+  ({ className, children, type = "button", ...props }, ref) => {
+    return (
+      <button className={classNames(styles.BaseButton, className)} ref={ref} type={type} {...props}>
+        {children}
+      </button>
+    );
+  },
+);
+
+export default BaseButton;

--- a/src/components/ui/BaseButton/BaseButton.types.ts
+++ b/src/components/ui/BaseButton/BaseButton.types.ts
@@ -1,0 +1,6 @@
+export interface ButtonOwnProps {
+  as?: React.ElementType;
+  text?: string;
+}
+
+export type BaseButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;

--- a/src/components/ui/Button/Button.module.scss
+++ b/src/components/ui/Button/Button.module.scss
@@ -19,3 +19,21 @@
     @include buttonSecondary;
   }
 }
+
+.ButtonStory {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  .Wrapper {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    width: 300px;
+  }
+
+  .Text {
+    font-size: 1.125rem;
+    width: 120px;
+  }
+}

--- a/src/components/ui/Button/Button.module.scss
+++ b/src/components/ui/Button/Button.module.scss
@@ -1,15 +1,29 @@
+@use "@/styles/mixins" as *;
+
 .Button {
   cursor: pointer;
   margin: 0;
-  padding: 0;
   border: none;
+  border-radius: 0.875rem;
+  padding: 0.875rem;
+  width: 100%;
+  height: 3.25rem;
 
   &.style-primary {
     background-color: var(--color-text01);
     color: var(--color-white);
+    @include buttonPrimary;
   }
 
   &.style-secondary {
-    background-color: red;
+    background-color: var(--color-gray400);
+    color: var(--color-white);
+    @include buttonSecondary;
+  }
+
+  &.style-disabled {
+    background-color: var(--color-gray350);
+    color: var(--color-text03);
+    @include buttonSecondary;
   }
 }

--- a/src/components/ui/Button/Button.module.scss
+++ b/src/components/ui/Button/Button.module.scss
@@ -1,22 +1,27 @@
 @use "@/styles/mixins" as *;
 
 .Button {
+  @include buttonSecondary;
+
   &.style-primary {
     background-color: var(--color-text01);
     color: var(--color-white);
-    @include buttonPrimary;
   }
 
   &.style-secondary {
     background-color: var(--color-gray400);
     color: var(--color-white);
-    @include buttonSecondary;
   }
 
-  &.style-disabled {
+  &.style-tertiary {
+    background-color: var(--color-gray200);
+    color: var(--color-text02);
+  }
+
+  &:disabled {
     background-color: var(--color-gray350);
     color: var(--color-text03);
-    @include buttonSecondary;
+    cursor: not-allowed;
   }
 }
 
@@ -29,6 +34,7 @@
     display: flex;
     gap: 1rem;
     justify-content: center;
+    align-items: center;
     width: 300px;
   }
 

--- a/src/components/ui/Button/Button.module.scss
+++ b/src/components/ui/Button/Button.module.scss
@@ -1,14 +1,6 @@
 @use "@/styles/mixins" as *;
 
 .Button {
-  cursor: pointer;
-  margin: 0;
-  border: none;
-  border-radius: 0.875rem;
-  padding: 0.875rem;
-  width: 100%;
-  height: 3.25rem;
-
   &.style-primary {
     background-color: var(--color-text01);
     color: var(--color-white);

--- a/src/components/ui/Button/Button.module.scss
+++ b/src/components/ui/Button/Button.module.scss
@@ -1,0 +1,15 @@
+.Button {
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+  border: none;
+
+  &.style-primary {
+    background-color: var(--color-text01);
+    color: var(--color-white);
+  }
+
+  &.style-secondary {
+    background-color: red;
+  }
+}

--- a/src/components/ui/Button/Button.stories.tsx
+++ b/src/components/ui/Button/Button.stories.tsx
@@ -1,0 +1,43 @@
+import Button from "@/components/ui/Button/Button";
+import styles from "@/components/ui/Button/Button.module.scss";
+import type { ButtonProps } from "@/components/ui/Button/Button.types";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Button> = {
+  title: "Example/Button",
+  component: Button,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["!autodocs"],
+};
+
+export default meta;
+
+export const Primary: StoryObj<ButtonProps> = {
+  args: {
+    text: "정보가 맞아요",
+    disabled: false,
+    variant: "primary",
+  },
+};
+
+export const VariantProps: StoryObj<typeof Button> = {
+  render: () => (
+    <div className={styles.ButtonStory}>
+      <div className={styles.Wrapper}>
+        <p className={styles.Text}>primary</p>
+        <Button variant="primary" text="정보가 맞아요" />
+      </div>
+      <div className={styles.Wrapper}>
+        <p className={styles.Text}>secondary</p>
+        <Button variant="secondary" text="정보가 맞아요" />
+      </div>
+      <div className={styles.Wrapper}>
+        <p className={styles.Text}>disabled</p>
+        <Button variant="disabled" text="정보가 맞아요" />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/Button/Button.stories.tsx
+++ b/src/components/ui/Button/Button.stories.tsx
@@ -35,8 +35,8 @@ export const VariantProps: StoryObj<typeof Button> = {
         <Button variant="secondary" text="정보가 맞아요" />
       </div>
       <div className={styles.Wrapper}>
-        <p className={styles.Text}>disabled</p>
-        <Button variant="disabled" text="정보가 맞아요" />
+        <p className={styles.Text}>tertiary</p>
+        <Button variant="tertiary" text="정보가 맞아요" />
       </div>
     </div>
   ),

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,20 +1,37 @@
-import React from "react";
+import React, { useCallback } from "react";
 
 import classNames from "classnames";
 
+import BaseButton from "@/components/ui/BaseButton/BaseButton";
 import styles from "@/components/ui/Button/Button.module.scss";
 import type { ButtonProps } from "@/components/ui/Button/Button.types";
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "primary", text, ...props }, ref) => {
+  (
+    { as = BaseButton, className, variant = "primary", text, disabled = false, onClick, ...props },
+    ref,
+  ) => {
+    const Comp = as as typeof BaseButton;
+
+    const handleClick = useCallback(
+      (e: React.MouseEvent<HTMLButtonElement>) => {
+        if (!disabled) {
+          onClick?.(e);
+        }
+      },
+      [onClick, disabled],
+    );
+
     return (
-      <button
-        className={classNames(styles.Button, styles[`style-${variant}`], className)}
+      <Comp
         ref={ref}
+        className={classNames(styles.Button, styles[`style-${variant}`], className)}
+        disabled={disabled}
+        onClick={handleClick}
         {...props}
       >
         {text}
-      </button>
+      </Comp>
     );
   },
 );

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import classNames from "classnames";
+
+import styles from "@/components/ui/Button/Button.module.scss";
+import type { ButtonProps } from "@/components/ui/Button/Button.types";
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "primary", ...props }, ref) => {
+    return (
+      <button
+        className={classNames(styles.Button, styles[`style-${variant}`], className)}
+        ref={ref}
+        {...props}
+      >
+        button
+      </button>
+    );
+  },
+);
+
+export default Button;

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -6,14 +6,14 @@ import styles from "@/components/ui/Button/Button.module.scss";
 import type { ButtonProps } from "@/components/ui/Button/Button.types";
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "primary", ...props }, ref) => {
+  ({ className, variant = "primary", text, ...props }, ref) => {
     return (
       <button
         className={classNames(styles.Button, styles[`style-${variant}`], className)}
         ref={ref}
         {...props}
       >
-        button
+        {text}
       </button>
     );
   },

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import { forwardRef, useCallback } from "react";
 
 import classNames from "classnames";
 
@@ -6,7 +6,7 @@ import BaseButton from "@/components/ui/BaseButton/BaseButton";
 import styles from "@/components/ui/Button/Button.module.scss";
 import type { ButtonProps } from "@/components/ui/Button/Button.types";
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     { as = BaseButton, className, variant = "primary", text, disabled = false, onClick, ...props },
     ref,

--- a/src/components/ui/Button/Button.types.ts
+++ b/src/components/ui/Button/Button.types.ts
@@ -1,4 +1,4 @@
-export type ButtonVariant = "primary" | "secondary";
+export type ButtonVariant = "primary" | "secondary" | "disabled";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   type?: "button" | "submit";

--- a/src/components/ui/Button/Button.types.ts
+++ b/src/components/ui/Button/Button.types.ts
@@ -1,6 +1,6 @@
 import type { ButtonOwnProps } from "@/components/ui/BaseButton/BaseButton.types";
 
-type ButtonVariant = "primary" | "secondary" | "disabled";
+type ButtonVariant = "primary" | "secondary" | "tertiary";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, ButtonOwnProps {
   variant?: ButtonVariant;

--- a/src/components/ui/Button/Button.types.ts
+++ b/src/components/ui/Button/Button.types.ts
@@ -1,7 +1,7 @@
-export type ButtonVariant = "primary" | "secondary" | "disabled";
+import type { ButtonOwnProps } from "@/components/ui/BaseButton/BaseButton.types";
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  type?: "button" | "submit";
-  text?: string;
+type ButtonVariant = "primary" | "secondary" | "disabled";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, ButtonOwnProps {
   variant?: ButtonVariant;
 }

--- a/src/components/ui/Button/Button.types.ts
+++ b/src/components/ui/Button/Button.types.ts
@@ -1,0 +1,7 @@
+export type ButtonVariant = "primary" | "secondary";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  type?: "button" | "submit";
+  text?: string;
+  variant?: ButtonVariant;
+}

--- a/src/components/ui/Icon/Icon.module.scss
+++ b/src/components/ui/Icon/Icon.module.scss
@@ -1,0 +1,20 @@
+.IconStory {
+  display: flex;
+  align-items: center;
+  gap: 4rem;
+
+  .Wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+
+    .InnerWrapper {
+      width: 1.5rem;
+      height: 1.5rem;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  }
+}

--- a/src/components/ui/Icon/Icon.stories.tsx
+++ b/src/components/ui/Icon/Icon.stories.tsx
@@ -1,6 +1,7 @@
 import Icon from "@/components/ui/Icon/Icon";
 import { ICONS } from "@/components/ui/Icon/Icon";
-import type { IconNameType } from "@/components/ui/Icon/Icon";
+import type { IconNameType, IconProps } from "@/components/ui/Icon/Icon";
+import styles from "@/components/ui/Icon/Icon.module.scss";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -10,34 +11,23 @@ const meta: Meta<typeof Icon> = {
   parameters: {
     layout: "centered",
   },
-  argTypes: {
-    name: {
-      control: {
-        type: "select",
-        options: ["camera", "close", "gallery", "leftArrow", "paste", "plus"],
-      },
-    },
-  },
+  tags: ["!autodocs"],
 };
 
 export default meta;
 
-export const AllIcons: StoryObj<typeof Icon> = {
+export const Primary: StoryObj<IconProps> = {
+  args: {
+    name: "camera",
+  },
+};
+
+export const AllIcons: StoryObj<IconProps> = {
   render: () => (
-    <div style={{ display: "flex", alignItems: "center", gap: "4rem" }}>
+    <div className={styles.IconStory}>
       {(Object.keys(ICONS) as IconNameType[]).map((iconName) => (
-        <div
-          style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "1rem" }}
-        >
-          <div
-            style={{
-              width: "1.5rem",
-              height: "1.5rem",
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-            }}
-          >
+        <div className={styles.Wrapper}>
+          <div className={styles.InnerWrapper}>
             <Icon name={iconName} />
           </div>
           <p>{iconName}</p>

--- a/src/components/ui/Icon/Icon.tsx
+++ b/src/components/ui/Icon/Icon.tsx
@@ -7,6 +7,10 @@ import PlusIcon from "@/assets/svg/ic-plus.svg?react";
 
 export type IconNameType = "camera" | "close" | "gallery" | "leftArrow" | "paste" | "plus";
 
+export interface IconProps {
+  name: IconNameType;
+}
+
 export const ICONS = {
   camera: CameraIcon,
   close: CloseIcon,
@@ -17,7 +21,7 @@ export const ICONS = {
 };
 
 // 추후 사이즈, 컬러등 추가 가능
-const Icon = ({ name }: { name: IconNameType }) => {
+const Icon = ({ name }: IconProps) => {
   const SvgIcon = ICONS[name];
 
   return <SvgIcon />;

--- a/src/components/ui/IconButton/IconButton.module.scss
+++ b/src/components/ui/IconButton/IconButton.module.scss
@@ -1,0 +1,31 @@
+@use "@/styles/mixins" as *;
+
+.IconButton {
+  cursor: pointer;
+  margin: 0;
+  border: none;
+  border-radius: 0.875rem;
+  padding: 0.875rem;
+  width: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &.size-md {
+    gap: 0.375rem;
+    height: 3.25rem;
+    background-color: var(--color-gray400);
+    color: var(--color-white);
+    @include buttonSecondary;
+  }
+
+  &.size-sm {
+    gap: 0.125rem;
+    height: 2.375rem;
+    background-color: var(--color-text01);
+    color: var(--color-white);
+    border-radius: 0.75rem;
+    @include buttonTertiary;
+  }
+}

--- a/src/components/ui/IconButton/IconButton.module.scss
+++ b/src/components/ui/IconButton/IconButton.module.scss
@@ -1,20 +1,12 @@
 @use "@/styles/mixins" as *;
 
 .IconButton {
-  cursor: pointer;
-  margin: 0;
-  border: none;
-  border-radius: 0.875rem;
-  padding: 0.875rem;
-  width: 100%;
-
   display: flex;
   justify-content: center;
   align-items: center;
 
   &.size-md {
     gap: 0.375rem;
-    height: 3.25rem;
     background-color: var(--color-gray400);
     color: var(--color-white);
     @include buttonSecondary;

--- a/src/components/ui/IconButton/IconButton.module.scss
+++ b/src/components/ui/IconButton/IconButton.module.scss
@@ -15,6 +15,7 @@
   &.size-sm {
     gap: 0.125rem;
     height: 2.375rem;
+    padding: 0.5rem 0.875rem;
     background-color: var(--color-text01);
     color: var(--color-white);
     border-radius: 0.75rem;

--- a/src/components/ui/IconButton/IconButton.module.scss
+++ b/src/components/ui/IconButton/IconButton.module.scss
@@ -21,3 +21,21 @@
     @include buttonTertiary;
   }
 }
+
+.IconButtonStory {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  .Wrapper {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .Text {
+    font-size: 1.125rem;
+    width: 120px;
+  }
+}

--- a/src/components/ui/IconButton/IconButton.stories.tsx
+++ b/src/components/ui/IconButton/IconButton.stories.tsx
@@ -1,0 +1,50 @@
+import IconButton from "@/components/ui/IconButton/IconButton";
+import styles from "@/components/ui/IconButton/IconButton.module.scss";
+import type { IconButtonProps } from "@/components/ui/IconButton/IconButton.types";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof IconButton> = {
+  title: "Example/IconButton",
+  component: IconButton,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["!autodocs"],
+};
+
+export default meta;
+
+export const Primary: StoryObj<IconButtonProps> = {
+  args: {
+    text: "갤러리",
+    iconName: "gallery",
+    size: "md",
+  },
+};
+
+export const IconNameProps: StoryObj<typeof IconButton> = {
+  render: () => (
+    <div className={styles.IconButtonStory}>
+      <div className={styles.Wrapper}>
+        <p className={styles.Text}>gallery</p>
+        <IconButton text="갤러리" iconName="gallery" />
+      </div>
+      <div className={styles.Wrapper}>
+        <p className={styles.Text}>camera</p>
+        <IconButton text="카메라" iconName="camera" />
+      </div>
+    </div>
+  ),
+};
+
+export const SizeProps: StoryObj<typeof IconButton> = {
+  render: () => (
+    <div className={styles.IconButtonStory}>
+      <div className={styles.Wrapper}>
+        <p className={styles.Text}>sm</p>
+        <IconButton size="sm" text="복사하기" iconName="paste" />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/IconButton/IconButton.tsx
+++ b/src/components/ui/IconButton/IconButton.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import classNames from "classnames";
+
+import Icon from "@/components/ui/Icon/Icon";
+import styles from "@/components/ui/IconButton/IconButton.module.scss";
+import type { IconButtonProps } from "@/components/ui/IconButton/IconButton.types";
+
+const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({ className, size = "md", text, iconName, ...props }, ref) => {
+    return (
+      <button
+        className={classNames(styles.IconButton, styles[`size-${size}`], className)}
+        ref={ref}
+        {...props}
+      >
+        <Icon name={iconName} />
+        {text}
+      </button>
+    );
+  },
+);
+
+export default IconButton;

--- a/src/components/ui/IconButton/IconButton.tsx
+++ b/src/components/ui/IconButton/IconButton.tsx
@@ -1,22 +1,48 @@
-import React from "react";
+import React, { useCallback } from "react";
 
 import classNames from "classnames";
 
+import BaseButton from "@/components/ui/BaseButton/BaseButton";
 import Icon from "@/components/ui/Icon/Icon";
 import styles from "@/components/ui/IconButton/IconButton.module.scss";
 import type { IconButtonProps } from "@/components/ui/IconButton/IconButton.types";
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ className, size = "md", text, iconName, ...props }, ref) => {
+  (
+    {
+      as = BaseButton,
+      className,
+      size = "md",
+      disabled = false,
+      onClick,
+      text,
+      iconName,
+      ...props
+    },
+    ref,
+  ) => {
+    const Comp = as as typeof BaseButton;
+
+    const handleClick = useCallback(
+      (e: React.MouseEvent<HTMLButtonElement>) => {
+        if (!disabled) {
+          onClick?.(e);
+        }
+      },
+      [onClick, disabled],
+    );
+
     return (
-      <button
-        className={classNames(styles.IconButton, styles[`size-${size}`], className)}
+      <Comp
         ref={ref}
+        className={classNames(styles.IconButton, styles[`size-${size}`], className)}
+        disabled={disabled}
+        onClick={handleClick}
         {...props}
       >
         <Icon name={iconName} />
         {text}
-      </button>
+      </Comp>
     );
   },
 );

--- a/src/components/ui/IconButton/IconButton.types.ts
+++ b/src/components/ui/IconButton/IconButton.types.ts
@@ -1,0 +1,10 @@
+import type { IconNameType } from "@/components/ui/Icon/Icon";
+
+export type IconButtonSize = "md" | "sm";
+
+export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  type?: "button" | "submit";
+  text?: string;
+  size?: IconButtonSize;
+  iconName: IconNameType;
+}

--- a/src/components/ui/IconButton/IconButton.types.ts
+++ b/src/components/ui/IconButton/IconButton.types.ts
@@ -1,10 +1,11 @@
+import type { ButtonOwnProps } from "@/components/ui/BaseButton/BaseButton.types";
 import type { IconNameType } from "@/components/ui/Icon/Icon";
 
-export type IconButtonSize = "md" | "sm";
+type IconButtonSize = "md" | "sm";
 
-export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  type?: "button" | "submit";
-  text?: string;
+export interface IconButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    ButtonOwnProps {
   size?: IconButtonSize;
   iconName: IconNameType;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import App from "@/App";
 import ReactQueryClientProvider from "@/components/provider/ReactQueryClientProvider";
 
 import "@/styles/reset.scss";
+import "@/styles/global.scss";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -33,17 +33,17 @@
   font-weight: var(--font-weight-medium);
 }
 
-@mixin buttonMd {
+@mixin buttonPrimary {
   font-size: var(--font-size-default);
   font-weight: var(--font-weight-semi-bold);
 }
 
-@mixin buttonSm {
+@mixin buttonSecondary {
   font-size: var(--font-size-default);
   font-weight: var(--font-weight-medium);
 }
 
-@mixin buttonXs {
+@mixin buttonTertiary {
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-medium);
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -4,13 +4,13 @@
   --font-weight-semi-bold: 600;
   --font-weight-bold: 700;
 
-  --font-size-xl: 28px;
-  --font-size-lg: 24px;
-  --font-size-md: 22px;
-  --font-size-default: 16px;
-  --font-size-sm: 15px;
-  --font-size-xs: 14px;
-  --font-size-xxs: 13px;
+  --font-size-xl: 1.75rem;
+  --font-size-lg: 1.5rem;
+  --font-size-md: 1.375rem;
+  --font-size-default: 1rem;
+  --font-size-sm: 0.9375rem;
+  --font-size-xs: 0.875rem;
+  --font-size-xxs: 0.8125rem;
 
   --color-white: #fff;
   --color-black: #000;
@@ -22,6 +22,7 @@
   --color-gray100: #f8f8f8;
   --color-gray200: #ebecf0;
   --color-gray300: #e1e2e8;
+  --color-gray350: #dcdde3;
   --color-gray400: #00000026;
   --color-gray500: #00000040;
   --color-gray600: #363642;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,0 +1,29 @@
+* {
+  font-family: "Pretendard", sans-serif;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+body {
+  max-width: 37.5rem;
+  margin: 0 auto;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+button {
+  border: none;
+  outline: none;
+  background-color: transparent;
+}
+
+input,
+textarea {
+  border: none;
+  outline: none;
+  background-color: transparent;
+}

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -128,7 +128,3 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
-
-* {
-  font-family: "Pretendard", sans-serif;
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,5 +27,5 @@
     "plugins": [{ "name": "typescript-plugin-css-modules" }],
     "types": ["@testing-library/jest-dom", "vite-plugin-svgr/client", "vite/client"]
   },
-  "include": ["src", "src/types"]
+  "include": ["src", "src/types", ".storybook/**/*"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,15 +11,18 @@ export default defineConfig({
   base: "/",
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(__dirname, "src"),
     },
   },
   css: {
+    modules: {
+      localsConvention: "camelCase",
+    },
     preprocessorOptions: {
       scss: {
         additionalData: `
-          @use "@/styles/_variables.scss" as *;
-          @use "@/styles/_mixins.scss" as *;
+          @use "@/styles/_variables.scss";
+          @use "@/styles/_mixins.scss";
         `,
       },
     },


### PR DESCRIPTION
- [https://github.com/Nexters/misik-web/issues/9](https://github.com/Nexters/misik-web/issues/9)

## 💡 변경사항 & 이슈
버튼 컴포넌트 제작

## ✍️ 관련 설명
Button, IconButton 컴포넌트 제작 완료
BaseButton은 위 버튼에 기본 틀로 생각하면 될 거 같고 직접적인 UI 컴포넌트는 아니야 (확장성 고려)

구성은 radix ui 오픈 소스랑 비슷해서 좀 더 프로페셔널(?)한 코드를 원한다면 오픈 소스 코드 한번 보면 좀 더 이해하기 쉬울 거 같아

storybook은 좀 더 확인하기 편하라고 미리 추가했는데 storybook docs나 test code 작성은 좀 이후에 작업할 예정이야

버튼은 종류별로 primary, secondary, disabled
아이콘 버튼은 사이즈별로 md, sm으로 나눠봤는데 더 좋은 의견 있으면 얘기 부탁해!

참고로 버튼 width들은 따로 지정 안했는데 버튼의 width를 지정하기보다 버튼 부모 컴포넌트의 width를 지정해서 작업하는게 나을 거 같아서 버튼 width들은 다 100% 기준이야. 어차피 버튼 크기가 고정이 아니라 반응형으로 달라지는게 더 좋을 거 같아서!

추가적으로 global.scss도 추가해줬어. 원래 reset.scss에 있다가 이후 설정 확장성을 고려해서 global.scss로 따로 뺏어
global 스타일들은 내 임의대로 지정했는데 혹시 의견 있으면 얘기해줘!


## ⭐️ Review point
- 누락된 버튼이나 추가해야할 버튼 있는지
- storybook에 잘 보이는지
- global 스타일 수정 or 개선점
- 이외 추가 의견

## 📷 Demo
<img width="412" alt="스크린샷 2025-01-30 오전 1 22 53" src="https://github.com/user-attachments/assets/8323e518-a7c1-443d-95bc-8fc7be67673d" />

