### PR TITLE
[Feat/#24] Tag 컴포넌트 제작

### DIFF
--- a/src/components/ui/Tag/Tag.module.scss
+++ b/src/components/ui/Tag/Tag.module.scss
@@ -1,0 +1,27 @@
+.Tag {
+  border-radius: 0.75rem;
+  height: 2.5rem;
+  background-color: var(--color-white);
+
+  &.Selected {
+    background-color: var(--color-gray600);
+  }
+
+  &.style-primary {
+    width: fit-content;
+    padding: 0.5rem 0.875rem;
+  }
+
+  &.style-add {
+    width: 2.5rem;
+    padding: 0.625rem;
+  }
+
+  & > span {
+    line-height: 1.5rem;
+  }
+
+  & > svg > path {
+    fill: var(--color-gray500);
+  }
+}

--- a/src/components/ui/Tag/Tag.module.scss
+++ b/src/components/ui/Tag/Tag.module.scss
@@ -25,3 +25,22 @@
     fill: var(--color-gray500);
   }
 }
+
+.TagStory {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  .Wrapper {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    align-items: center;
+    width: 300px;
+  }
+
+  .Text {
+    font-size: 1.125rem;
+    width: 120px;
+  }
+}

--- a/src/components/ui/Tag/Tag.stories.tsx
+++ b/src/components/ui/Tag/Tag.stories.tsx
@@ -1,0 +1,44 @@
+import Tag from "@/components/ui/Tag/Tag";
+import styles from "@/components/ui/Tag/Tag.module.scss";
+import type { TagProps } from "@/components/ui/Tag/Tag.types";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Tag> = {
+  title: "Example/Tag",
+  component: Tag,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["!autodocs"],
+};
+
+export default meta;
+
+export const Primary: StoryObj<TagProps> = {
+  args: {
+    text: "태그",
+    variant: "primary",
+    isSelect: false,
+  },
+};
+
+export const VariantProps: StoryObj<typeof Tag> = {
+  render: () => (
+    <div className={styles.TagStory}>
+      <div className={styles.Wrapper}>
+        <p className={styles.Text}>primary</p>
+        <Tag variant="primary" text="primary" />
+      </div>
+      <div className={styles.Wrapper}>
+        <p className={styles.Text}>add</p>
+
+        <Tag variant="add" text="add" />
+      </div>
+      <div className={styles.Wrapper}>
+        <p className={styles.Text}>isSelect</p>
+        <Tag variant="primary" text="isSelect" isSelect />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/Tag/Tag.tsx
+++ b/src/components/ui/Tag/Tag.tsx
@@ -1,0 +1,35 @@
+import { forwardRef } from "react";
+
+import classNames from "classnames";
+
+import Icon from "@/components/ui/Icon/Icon";
+import styles from "@/components/ui/Tag/Tag.module.scss";
+import type { TagProps } from "@/components/ui/Tag/Tag.types";
+import Text from "@/components/ui/Text/Text";
+
+const Tag = forwardRef<HTMLDivElement, TagProps>(
+  ({ variant = "primary", text, isSelect, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={classNames(
+          styles.Tag,
+          styles[`style-${variant}`],
+          { [styles.Selected]: isSelect },
+          className,
+        )}
+        {...props}
+      >
+        {variant === "primary" && (
+          <Text variant="bodyM" color={isSelect ? "white" : "secondary"}>
+            {text}
+          </Text>
+        )}
+
+        {variant === "add" && <Icon name="plus" />}
+      </div>
+    );
+  },
+);
+
+export default Tag;

--- a/src/components/ui/Tag/Tag.types.ts
+++ b/src/components/ui/Tag/Tag.types.ts
@@ -1,0 +1,7 @@
+type TagVariant = "primary" | "add";
+
+export interface TagProps extends React.HTMLAttributes<HTMLDivElement> {
+  text?: string;
+  variant?: TagVariant;
+  isSelect?: boolean;
+}


### PR DESCRIPTION
- [https://github.com/Nexters/misik-web/issues/24](https://github.com/Nexters/misik-web/issues/24)

## 💡 변경사항 & 이슈
Tag 컴포넌트 제작

## ✍️ 관련 설명
현재 디자인 상에서는 해시태그 선택 페이지에서만 해당되는 컴포넌트이지만 이후 더 추가될 수 있을 거 같고 아니더라도 Button 컴포넌트와는 차별점을 두기 위해서 Tag 컴포넌트를 만들어 봤어

일반적인 태그 primary variant랑, 아이콘 버튼 태그인 add variant로 나눠서 제작했고 선택 태그의 경우 isSelect props로 구분을 줬으니 확인해보면 될 거 같아

동일하게 스토리북도!

## ⭐️ Review point
- 태그 컴포넌트 의견, 개선점
- 스토리북 잘 보이는지

## 📷 Demo
<img width="212" alt="스크린샷 2025-02-01 오후 1 50 54" src="https://github.com/user-attachments/assets/60250163-91be-4fd0-9045-9a3322ac53d9" />

