### PR TITLE
[Feat/#25] 해시태그 선택 페이지 UI 제작

### DIFF
--- a/src/components/SelectTag/SelectTag.module.scss
+++ b/src/components/SelectTag/SelectTag.module.scss
@@ -1,0 +1,48 @@
+.SelectTag {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  padding-bottom: 2.5rem;
+  height: calc(100vh - 2.75rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: var(--color-bg-gradient);
+
+  &::before {
+    content: "";
+    background: url("/src/assets/svg/img-graphic-main.svg") center no-repeat;
+    background-size: 100% 16.375rem;
+    filter: blur(4.625rem);
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 0;
+  }
+}
+
+.Top {
+  z-index: 1;
+
+  .Title {
+    margin-top: 2.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+  }
+
+  .TagList {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.625rem;
+    margin-top: 2.5rem;
+  }
+}
+
+.Bottom {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  z-index: 1;
+}

--- a/src/components/SelectTag/SelectTag.tsx
+++ b/src/components/SelectTag/SelectTag.tsx
@@ -1,0 +1,47 @@
+import styles from "@/components/SelectTag/SelectTag.module.scss";
+import Button from "@/components/ui/Button/Button";
+import Tag from "@/components/ui/Tag/Tag";
+import Text from "@/components/ui/Text/Text";
+
+const TAG_LIST = [
+  "음식이 맛있어요",
+  "양이 많아요",
+  "가성비가 좋아요",
+  "메뉴 구성이 알차요",
+  "매장이 넓어요",
+  "단체모임 하기 좋아요",
+  "뷰가 좋아요",
+  "아늑해요",
+  "분위기가 좋아요",
+  "친절해요",
+  "매장이 청결해요",
+];
+
+const SelectTag = () => {
+  return (
+    <div className={styles.SelectTag}>
+      <div className={styles.Top}>
+        <div className={styles.Title}>
+          <Text variant="titleM" color="primary">
+            어떠셨나요?
+          </Text>
+          <Text variant="bodySm" color="tertiary">
+            복수 가능
+          </Text>
+        </div>
+        <div className={styles.TagList}>
+          {TAG_LIST.map((tag) => (
+            <Tag text={tag} key={tag} />
+          ))}
+          <Tag variant="add" />
+        </div>
+      </div>
+
+      <div className={styles.Bottom}>
+        <Button text="다음" />
+      </div>
+    </div>
+  );
+};
+
+export default SelectTag;

--- a/src/components/SelectTag/SelectTag.tsx
+++ b/src/components/SelectTag/SelectTag.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
+
 import styles from "@/components/SelectTag/SelectTag.module.scss";
 import Button from "@/components/ui/Button/Button";
 import Tag from "@/components/ui/Tag/Tag";
 import Text from "@/components/ui/Text/Text";
 
+// 임시 데이터
 const TAG_LIST = [
   "음식이 맛있어요",
   "양이 많아요",
@@ -18,6 +21,18 @@ const TAG_LIST = [
 ];
 
 const SelectTag = () => {
+  const [selectedTagList, setSelectedTagList] = useState<string[]>([]);
+
+  const handleTagClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    const tag = e.currentTarget.textContent || "";
+
+    if (selectedTagList.includes(tag)) {
+      setSelectedTagList(selectedTagList.filter((selectedTag) => selectedTag !== tag));
+    } else {
+      setSelectedTagList([...selectedTagList, tag]);
+    }
+  };
+
   return (
     <div className={styles.SelectTag}>
       <div className={styles.Top}>
@@ -31,7 +46,12 @@ const SelectTag = () => {
         </div>
         <div className={styles.TagList}>
           {TAG_LIST.map((tag) => (
-            <Tag text={tag} key={tag} />
+            <Tag
+              text={tag}
+              key={tag}
+              onClick={handleTagClick}
+              isSelect={selectedTagList.includes(tag)}
+            />
           ))}
           <Tag variant="add" />
         </div>

--- a/src/pages/SelectTagPage.tsx
+++ b/src/pages/SelectTagPage.tsx
@@ -1,0 +1,13 @@
+import Navbar from "@/components/common/Navbar";
+import SelectTag from "@/components/SelectTag/SelectTag";
+
+const SelectTagPage = () => {
+  return (
+    <>
+      <Navbar />
+      <SelectTag />
+    </>
+  );
+};
+
+export default SelectTagPage;

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -5,6 +5,7 @@ import App from "@/App";
 import HomePage from "@/pages/HomePage";
 import ReceiptEditPage from "@/pages/ReceiptEditPage";
 import RecognitionFailPage from "@/pages/RecognitionFailPage";
+import SelectTagPage from "@/pages/SelectTagPage";
 
 const AppRouter = () => {
   const router = createBrowserRouter([
@@ -23,6 +24,10 @@ const AppRouter = () => {
         {
           path: "/receipt-edit",
           element: <ReceiptEditPage />,
+        },
+        {
+          path: "/select-tag",
+          element: <SelectTagPage />,
         },
       ],
     },


### PR DESCRIPTION
- [https://github.com/Nexters/misik-web/issues/25](https://github.com/Nexters/misik-web/issues/25)

## 💡 변경사항 & 이슈
해시태그 선택 페이지 ui 제작

## ✍️ 관련 설명
페이지 UI랑 태그 선택, 복수 선택 기능까지 구현한 상태야

+버튼 클릭 시 팝업 시트는 다음 브랜치에서 구현 예정이고, tag list 데이터는 임시용이라 UT 이후에 아마 바뀌지 않을까 싶네

페이지 UI는 /select-tag에서 확인 가능해!

## ⭐️ Review point
- 로직 개선점
- 이외 의견이나 피드백

## 📷 Demo

<img width="448" alt="스크린샷 2025-02-01 오후 7 21 30" src="https://github.com/user-attachments/assets/41039b91-3083-4c59-a42c-83b3b5483d9f" />

