### PR TITLE
[Feat/#40] 홈 이동 안내 팝업 모달 제작

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<div id="modal"></div>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,8 +1,13 @@
 import styles from "@/components/Home/Home.module.scss";
+import HomeNavigateConfirmModal from "@/components/HomeNavigateConfirmModal/HomeNavigateConfirmModal";
 import IconButton from "@/components/ui/IconButton/IconButton";
 import Text from "@/components/ui/Text/Text";
 
+import { useOverlay } from "@/hooks/common/useOverlay";
+
 const Home = () => {
+  const { isOpen, handleClose, handleOpen } = useOverlay();
+
   return (
     <div className={styles.Home}>
       <div className={styles.HomeTitle}>
@@ -17,9 +22,11 @@ const Home = () => {
         <img src="/assets/img/img-graphic-logo.png" alt="mainLogo" />
       </div>
       <div className={styles.HomeBottom}>
-        <IconButton text="갤러리" iconName="gallery" />
+        <IconButton text="갤러리" iconName="gallery" onClick={handleOpen} />
         <IconButton text="카메라" iconName="camera" />
       </div>
+
+      <HomeNavigateConfirmModal isOpen={isOpen} handleClose={handleClose} />
     </div>
   );
 };

--- a/src/components/HomeNavigateConfirmModal/HomeNavigateConfirmModal.module.scss
+++ b/src/components/HomeNavigateConfirmModal/HomeNavigateConfirmModal.module.scss
@@ -1,0 +1,36 @@
+.Modal {
+  padding: 1.875rem 1.25rem 1.25rem;
+
+  & > span {
+    margin-top: 0.375rem;
+  }
+}
+
+.ButtonWrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  margin-top: 1.5rem;
+
+  & > button {
+    width: 8.75rem;
+  }
+}
+
+.ShowButtonWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  margin-top: 0.75rem;
+
+  & > svg > path {
+    fill: rgba(0, 0, 0, 0.15);
+  }
+
+  &.isChecked {
+    & > svg > path {
+      fill: rgb(54, 54, 66);
+    }
+  }
+}

--- a/src/components/HomeNavigateConfirmModal/HomeNavigateConfirmModal.module.scss
+++ b/src/components/HomeNavigateConfirmModal/HomeNavigateConfirmModal.module.scss
@@ -23,6 +23,8 @@
   justify-content: center;
   gap: 0.375rem;
   margin-top: 0.75rem;
+  width: 100%;
+  cursor: pointer;
 
   & > svg > path {
     fill: rgba(0, 0, 0, 0.15);

--- a/src/components/HomeNavigateConfirmModal/HomeNavigateConfirmModal.stories.tsx
+++ b/src/components/HomeNavigateConfirmModal/HomeNavigateConfirmModal.stories.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import classNames from "classnames";
 
@@ -9,26 +8,21 @@ import Icon from "@/components/ui/Icon/Icon";
 import Modal from "@/components/ui/Modal/Modal";
 import Text from "@/components/ui/Text/Text";
 
+import { useOverlay } from "@/hooks/common/useOverlay";
+
+import type { Meta, StoryObj, StoryFn } from "@storybook/react";
+
 interface HomeNavigateConfirmModalProps {
   isOpen: boolean;
   handleClose: () => void;
 }
 
-const HomeNavigateConfirmModal = ({ isOpen, handleClose }: HomeNavigateConfirmModalProps) => {
-  const navigate = useNavigate();
-
-  // 이후 상태 초기값 재설정
+const HomeNavigateConfirmModalStory = ({ isOpen, handleClose }: HomeNavigateConfirmModalProps) => {
   const [isShowButtonChecked, setIsShowButtonChecked] = useState(false);
 
   const handleShowButtonClick = () => {
     setIsShowButtonChecked((prev) => !prev);
   };
-
-  const handleNavigateHome = () => {
-    handleClose();
-    navigate("/");
-  };
-
   return (
     <Modal isOpen={isOpen}>
       <div className={styles.Modal}>
@@ -40,7 +34,7 @@ const HomeNavigateConfirmModal = ({ isOpen, handleClose }: HomeNavigateConfirmMo
         </Text>
         <div className={styles.ButtonWrapper}>
           <Button text="아니요" variant="tertiary" onClick={handleClose} />
-          <Button text="네" variant="primary" onClick={handleNavigateHome} />
+          <Button text="네" variant="primary" onClick={handleClose} />
         </div>
         <button
           className={classNames(styles.ShowButtonWrapper, {
@@ -58,4 +52,30 @@ const HomeNavigateConfirmModal = ({ isOpen, handleClose }: HomeNavigateConfirmMo
   );
 };
 
-export default HomeNavigateConfirmModal;
+const meta: Meta<typeof HomeNavigateConfirmModalStory> = {
+  title: "Example/HomeNavigateConfirmModal",
+  component: HomeNavigateConfirmModalStory,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["!autodocs"],
+};
+
+export default meta;
+
+const ModalTemplate = () => {
+  const { isOpen, handleOpen, handleClose } = useOverlay();
+
+  return (
+    <>
+      <Button text="open modal" onClick={handleOpen} />
+      <HomeNavigateConfirmModalStory isOpen={isOpen} handleClose={handleClose} />
+    </>
+  );
+};
+
+const Template: StoryFn<typeof ModalTemplate> = ModalTemplate;
+
+export const ModalStory: StoryObj<HomeNavigateConfirmModalProps> = {
+  render: Template,
+};

--- a/src/components/HomeNavigateConfirmModal/HomeNavigateConfirmModal.tsx
+++ b/src/components/HomeNavigateConfirmModal/HomeNavigateConfirmModal.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import classNames from "classnames";
+
+import styles from "@/components/HomeNavigateConfirmModal/HomeNavigateConfirmModal.module.scss";
+import Button from "@/components/ui/Button/Button";
+import Icon from "@/components/ui/Icon/Icon";
+import Modal from "@/components/ui/Modal/Modal";
+import Text from "@/components/ui/Text/Text";
+
+interface HomeNavigateConfirmModalProps {
+  isOpen: boolean;
+  handleClose: () => void;
+}
+
+const HomeNavigateConfirmModal = ({ isOpen, handleClose }: HomeNavigateConfirmModalProps) => {
+  const navigate = useNavigate();
+
+  // 이후 상태 초기값 재설정
+  const [isShowButtonChecked, setIsShowButtonChecked] = useState(false);
+
+  const handleShowButtonClick = () => {
+    setIsShowButtonChecked((prev) => !prev);
+  };
+
+  const handleNavigateHome = () => {
+    handleClose();
+    navigate("/");
+  };
+
+  return (
+    <Modal isOpen={isOpen}>
+      <div className={styles.Modal}>
+        <Text variant="titleSm" color="primary" align="center" as="h2">
+          홈으로 가시겠어요?
+        </Text>
+        <Text variant="bodyM" color="secondary" align="center" as="p">
+          복사하지 않은 리뷰는 삭제돼요.
+        </Text>
+        <div className={styles.ButtonWrapper}>
+          <Button text="아니요" variant="tertiary" onClick={handleClose} />
+          <Button text="네" variant="primary" onClick={handleNavigateHome} />
+        </div>
+        <div
+          className={classNames(styles.ShowButtonWrapper, {
+            [styles.isChecked]: isShowButtonChecked,
+          })}
+          onClick={handleShowButtonClick}
+        >
+          <Icon name="checkCircle" />
+          <Text variant="bodyXsm" color={isShowButtonChecked ? "primary" : "tertiary"}>
+            다시 안볼래요
+          </Text>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default HomeNavigateConfirmModal;

--- a/src/components/ui/Modal/Modal.module.scss
+++ b/src/components/ui/Modal/Modal.module.scss
@@ -3,6 +3,10 @@
   inset: 0;
   background-color: rgba(0, 0, 0, 0.3);
   z-index: 99;
+
+  &.Open {
+    animation: animation-show 300ms cubic-bezier(0.3, 0, 0, 1);
+  }
 }
 
 .Modal {
@@ -13,4 +17,18 @@
   z-index: 100;
   background-color: var(--color-white);
   border-radius: 1.25rem;
+
+  &.Open {
+    animation: animation-show 300ms cubic-bezier(0.3, 0, 0, 1);
+  }
+}
+
+@keyframes animation-show {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }

--- a/src/components/ui/Modal/Modal.module.scss
+++ b/src/components/ui/Modal/Modal.module.scss
@@ -1,0 +1,16 @@
+.ModalBackdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 99;
+}
+
+.Modal {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 100;
+  background-color: var(--color-white);
+  border-radius: 1.25rem;
+}

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -1,0 +1,34 @@
+import type { PropsWithChildren } from "react";
+import { useEffect } from "react";
+
+import Portal from "@/components/ui/Modal/Portal";
+
+import styles from "@/components/ui/Modal/Modal.module.css";
+
+interface ModalProps extends PropsWithChildren {
+  isOpen: boolean;
+}
+
+const Modal = ({ isOpen, children }: ModalProps) => {
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, []);
+
+  return (
+    <>
+      {isOpen && (
+        <Portal elementId="modal">
+          <div className={styles.ModalBackdrop} />
+
+          <div className={styles.Modal}>{children}</div>
+        </Portal>
+      )}
+    </>
+  );
+};
+
+export default Modal;

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -1,9 +1,8 @@
 import type { PropsWithChildren } from "react";
 import { useEffect } from "react";
 
+import styles from "@/components/ui/Modal/Modal.module.scss";
 import Portal from "@/components/ui/Modal/Portal";
-
-import styles from "@/components/ui/Modal/Modal.module.css";
 
 interface ModalProps extends PropsWithChildren {
   isOpen: boolean;

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -1,6 +1,8 @@
 import type { PropsWithChildren } from "react";
 import { useEffect } from "react";
 
+import classNames from "classnames";
+
 import styles from "@/components/ui/Modal/Modal.module.scss";
 import Portal from "@/components/ui/Modal/Portal";
 
@@ -21,9 +23,19 @@ const Modal = ({ isOpen, children }: ModalProps) => {
     <>
       {isOpen && (
         <Portal elementId="modal">
-          <div className={styles.ModalBackdrop} />
+          <div
+            className={classNames(styles.ModalBackdrop, {
+              [styles.Open]: isOpen,
+            })}
+          />
 
-          <div className={styles.Modal}>{children}</div>
+          <div
+            className={classNames(styles.Modal, {
+              [styles.Open]: isOpen,
+            })}
+          >
+            {children}
+          </div>
         </Portal>
       )}
     </>

--- a/src/components/ui/Modal/Portal.tsx
+++ b/src/components/ui/Modal/Portal.tsx
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+import type { PropsWithChildren } from "react";
+import { createPortal } from "react-dom";
+
+interface PortalProps extends PropsWithChildren {
+  elementId: string;
+}
+
+const Portal = ({ children, elementId }: PortalProps) => {
+  const rootElement = useMemo(() => document.getElementById(elementId), [elementId]);
+
+  return createPortal(children, rootElement as HTMLElement);
+};
+
+export default Portal;

--- a/src/hooks/common/useOverlay.ts
+++ b/src/hooks/common/useOverlay.ts
@@ -1,0 +1,19 @@
+import { useCallback, useState } from "react";
+
+export const useOverlay = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = useCallback(() => {
+    setIsOpen(true);
+  }, [setIsOpen]);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, [setIsOpen]);
+
+  const handleToggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  return { isOpen, handleOpen, handleClose, handleToggle };
+};


### PR DESCRIPTION
- [https://github.com/Nexters/misik-web/issues/40](https://github.com/Nexters/misik-web/issues/40)

## 💡 변경사항 & 이슈
공통 모달 컴포넌트 제작
홈 이동 안내 팝업 모달 제작

## ✍️ 관련 설명
우선 modal은 createPortal 사용해서 제작했어. createPortal에 elementId를 따로 추가한 이유는 modal말고 toast 메시지의 확장성이 생길 거 같아서 그때는 toast도 동일하게 portal을 사용할 예정이라 추가해줬어 (토스트 메시지 디자인 시안에 있더라구 웹에서 구현할지는 아직 미정)

그리고 지금은 home 컴포넌트에 갤러리 버튼에 modal을 붙여놨는데 이후에 리뷰 생성 완료 페이지 완성하면 거기로 옮기면 될 거 같아
테스트용으로는 여기다 유지해놓을게

/ 경로에서 갤러리 버튼 클릭하면 모달 확인 가능해

추가적으로 모달 컴포넌트 이름이 좀 마음에 안드는데.. 혹시 좋은 의견 있으면 얘기해줘! 아무리 생각해봐도 더 좋은 이름이 생각 안나더라..

(아이콘 이슈로 #34 코드를 pull해와서 #34 머지 이후에 rebase하고 머지 예정!)

## ⭐️ Review point
- 모달 로직 개선이나 의견
- 모달 컴포넌트 이름 의견
- 이외 피드백이나 추가 의견

## 📷 Demo
<img width="442" alt="스크린샷 2025-02-02 오후 6 28 39" src="https://github.com/user-attachments/assets/68d20d42-44d9-424b-84f5-1578c7a572a5" />

