### PR TITLE
feat: 앱 다운로드 링크 페이지 ios/안드로이드 리다이렉트 되도록 (#152)

### DIFF
--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -8,4 +8,6 @@ export const PATH = {
   REVIEW_RESULT: "/review-result",
   LOADING: "/loading",
   CREATE_REVIEW_FAIL: "/create-review-fail",
+  APP_DOWNLOAD: "/download",
+
 };

--- a/src/pages/DownloadPage/DownloadPage.tsx
+++ b/src/pages/DownloadPage/DownloadPage.tsx
@@ -1,0 +1,21 @@
+
+import { useUserAgent } from '@/components/provider/UserAgentProvider';
+
+export default function DownloadPage() {
+
+  const userAgent = useUserAgent();
+
+  const isIOS = userAgent.isIOS;
+
+  const iosAppStoreUrl = 'https://apps.apple.com/kr/app/%EB%AF%B8%EC%8B%9D-misik-ai-%EC%98%81%EC%88%98%EC%A6%9D-%EB%A6%AC%EB%B7%B0/id6741109313';
+  const androidPlayStoreUrl = 'https://play.google.com/store/apps/details?id=com.nexters.misik';
+
+  if (isIOS) {
+    window.location.href = iosAppStoreUrl;
+  } else{
+    window.location.href = androidPlayStoreUrl;
+  } 
+  return (
+    <></>
+  )
+}

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -5,6 +5,7 @@ import App from "@/App";
 import { PATH } from "@/constants/path";
 
 import CreateReviewFailPage from "@/pages/CreateReviewFailPage/CreateReviewFailPage";
+import DownloadPage from "@/pages/DownloadPage/DownloadPage";
 import HomePage from "@/pages/HomePage/HomePage";
 import LoadingPage from "@/pages/LoadingPage/LoadingPage";
 import ReceiptEditPage from "@/pages/ReceiptEditPage/ReceiptEditPage";
@@ -53,6 +54,7 @@ const AppRouter = () => {
           element: <ReviewResultPage />,
         },
         { path: PATH.CREATE_REVIEW_FAIL, element: <CreateReviewFailPage /> },
+        { path: PATH.APP_DOWNLOAD, element: <DownloadPage /> },
       ],
     },
   ]);


### PR DESCRIPTION
- [GITHUB ISSUE LINK](#152)

## 💡 변경사항 & 이슈

<br> 광고에 넣을 링크가 1개밖에 안들어가서 
  앱 다운로드 링크 페이지 ios/안드로이드 리다이렉트 되도록

## ✍️ 관련 설명

<br>

## ⭐️ Review point

<br>

## 📷 Demo

<br>
